### PR TITLE
Speed, minimum-XP, books, and selection limit

### DIFF
--- a/data.js
+++ b/data.js
@@ -4,141 +4,141 @@ var data = {
             levelMax: "4",
             weight: "1",
             incompatible: ["blast_protection", "fire_protection", "projectile_protection"],
-            items: ["helmet", "chestplate", "leggings", "boots", "turtle_shell"],
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "turtle_shell"],
             stylized: "Protection"
         },
         aqua_affinity: {
             levelMax: "1",
             weight: "2",
             incompatible: [],
-            items: ["helmet", "turtle_shell"],
+            items: ["book", "helmet", "turtle_shell"],
             stylized: "Aqua Affinity"
         },
         bane_of_arthropods: {
             levelMax: "5",
             weight: "1",
             incompatible: ["smite", "sharpness"],
-            items: ["sword", "axe"],
+            items: ["book", "sword", "axe"],
             stylized: "Bane of Arthropods"
         },
         blast_protection: {
             levelMax: "4",
             weight: "2",
             incompatible: ["fire_protection", "protection", "projectile_protection"],
-            items: ["helmet", "chestplate", "leggings", "boots", "turtle_shell"],
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "turtle_shell"],
             stylized: "Blast Protection"
         },
         channeling: {
             levelMax: "1",
             weight: "4",
             incompatible: ["riptide"],
-            items: ["trident"],
+            items: ["book", "trident"],
             stylized: "Channeling"
         },
         depth_strider: {
             levelMax: "3",
             weight: "2",
             incompatible: ["frost_walker"],
-            items: ["boots"],
+            items: ["book", "boots"],
             stylized: "Depth Strider"
         },
         efficiency: {
             levelMax: "5",
             weight: "1",
             incompatible: [],
-            items: ["pickaxe", "shovel", "axe", "hoe", "shears"],
+            items: ["book", "pickaxe", "shovel", "axe", "hoe", "shears"],
             stylized: "Efficiency"
         },
         feather_falling: {
             levelMax: "4",
             weight: "1",
             incompatible: [],
-            items: ["boots"],
+            items: ["book", "boots"],
             stylized: "Feather Falling"
         },
         fire_aspect: {
             levelMax: "2",
             weight: "2",
             incompatible: [],
-            items: ["sword"],
+            items: ["book", "sword"],
             stylized: "Fire Aspect"
         },
         fire_protection: {
             levelMax: "4",
             weight: "1",
             incompatible: ["blast_protection", "protection", "projectile_protection"],
-            items: ["helmet", "chestplate", "leggings", "boots", "turtle_shell"],
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "turtle_shell"],
             stylized: "Fire Protection"
         },
-        flame: { levelMax: "1", weight: "2", incompatible: [], items: ["bow"], stylized: "Flame" },
+        flame: { levelMax: "1", weight: "2", incompatible: [], items: ["book", "bow"], stylized: "Flame" },
         fortune: {
             levelMax: "3",
             weight: "2",
             incompatible: ["silk_touch"],
-            items: ["pickaxe", "shovel", "axe", "hoe"],
+            items: ["book", "pickaxe", "shovel", "axe", "hoe"],
             stylized: "Fortune"
         },
         frost_walker: {
             levelMax: "2",
             weight: "2",
             incompatible: ["depth_strider"],
-            items: ["boots"],
+            items: ["book", "boots"],
             stylized: "Frost Walker"
         },
         impaling: {
             levelMax: "5",
             weight: "2",
             incompatible: [],
-            items: ["trident"],
+            items: ["book", "trident"],
             stylized: "Impaling"
         },
         infinity: {
             levelMax: "1",
             weight: "4",
             incompatible: ["mending"],
-            items: ["bow"],
+            items: ["book", "bow"],
             stylized: "Infinity"
         },
         knockback: {
             levelMax: "2",
             weight: "1",
             incompatible: [],
-            items: ["sword"],
+            items: ["book", "sword"],
             stylized: "Knockback"
         },
         looting: {
             levelMax: "3",
             weight: "2",
             incompatible: [],
-            items: ["sword"],
+            items: ["book", "sword"],
             stylized: "Looting"
         },
         loyalty: {
             levelMax: "3",
             weight: "1",
             incompatible: ["riptide"],
-            items: ["trident"],
+            items: ["book", "trident"],
             stylized: "Loyalty"
         },
         luck_of_the_sea: {
             levelMax: "3",
             weight: "2",
             incompatible: [],
-            items: ["fishing_rod"],
+            items: ["book", "fishing_rod"],
             stylized: "Luck of the Sea"
         },
         lure: {
             levelMax: "3",
             weight: "2",
             incompatible: [],
-            items: ["fishing_rod"],
+            items: ["book", "fishing_rod"],
             stylized: "Lure"
         },
         mending: {
             levelMax: "1",
             weight: "2",
             incompatible: ["infinity"],
-            items: ["helmet", "chestplate", "leggings", "boots", "pickaxe", "shovel", "axe", "sword", "hoe", "brush", "fishing_rod",
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "pickaxe", "shovel", "axe", "sword", "hoe", "brush", "fishing_rod",
                 "bow", "shears", "flint_and_steel", "carrot_on_a_stick", "warped_fungus_on_a_stick", "shield", "elytra", "trident",
                 "turtle_shell", "crossbow"
             ],
@@ -148,105 +148,105 @@ var data = {
             levelMax: "1",
             weight: "2",
             incompatible: ["piercing"],
-            items: ["crossbow"],
+            items: ["book", "crossbow"],
             stylized: "Multishot"
         },
         piercing: {
             levelMax: "4",
             weight: "1",
             incompatible: ["multishot"],
-            items: ["crossbow"],
+            items: ["book", "crossbow"],
             stylized: "Piercing"
         },
         power: {
             levelMax: "5",
             weight: "1",
             incompatible: [],
-            items: ["bow"],
+            items: ["book", "bow"],
             stylized: "Power"
         },
         projectile_protection: {
             levelMax: "4",
             weight: "1",
             incompatible: ["protection", "blast_protection", "fire_protection"],
-            items: ["helmet", "chestplate", "leggings", "boots", "turtle_shell"],
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "turtle_shell"],
             stylized: "Projectile Protection"
         },
         punch: {
             levelMax: "2",
             weight: "2",
             incompatible: [],
-            items: ["bow"],
+            items: ["book", "bow"],
             stylized: "Punch"
         },
         quick_charge: {
             levelMax: "3",
             weight: "1",
             incompatible: [],
-            items: ["crossbow"],
+            items: ["book", "crossbow"],
             stylized: "Quick Charge"
         },
         respiration: {
             levelMax: "3",
             weight: "2",
             incompatible: [],
-            items: ["helmet", "turtle_shell"],
+            items: ["book", "helmet", "turtle_shell"],
             stylized: "Respiration"
         },
         riptide: {
             levelMax: "3",
             weight: "2",
             incompatible: ["channeling", "loyalty"],
-            items: ["trident"],
+            items: ["book", "trident"],
             stylized: "Riptide"
         },
         sharpness: {
             levelMax: "5",
             weight: "1",
             incompatible: ["bane_of_arthropods", "smite"],
-            items: ["sword", "axe"],
+            items: ["book", "sword", "axe"],
             stylized: "Sharpness"
         },
         silk_touch: {
             levelMax: "1",
             weight: "4",
             incompatible: ["fortune"],
-            items: ["pickaxe", "shovel", "axe", "hoe"],
+            items: ["book", "pickaxe", "shovel", "axe", "hoe"],
             stylized: "Silk Touch"
         },
         smite: {
             levelMax: "5",
             weight: "1",
             incompatible: ["bane_of_arthropods", "sharpness"],
-            items: ["sword", "axe"],
+            items: ["book", "sword", "axe"],
             stylized: "Smite"
         },
         soul_speed: {
             levelMax: "3",
             weight: "4",
             incompatible: [],
-            items: ["boots"],
+            items: ["book", "boots"],
             stylized: "Soul Speed"
         },
         sweeping: {
             levelMax: "3",
             weight: "2",
             incompatible: [],
-            items: ["sword"],
+            items: ["book", "sword"],
             stylized: "Sweeping Edge"
         },
         swift_sneak: {
             levelMax: "3",
             weight: "4",
             incompatible: [],
-            items: ["leggings"],
+            items: ["book", "leggings"],
             stylized: "Swift Sneak"
         },
         thorns: {
             levelMax: "3",
             weight: "4",
             incompatible: [],
-            items: ["helmet", "chestplate", "leggings", "boots", "turtle_shell"],
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "turtle_shell"],
             stylized: "Thorns"
         },
         unbreaking: {
@@ -254,8 +254,7 @@ var data = {
             weight: "1",
             incompatible: [],
             weight: "1",
-            items: [
-                "helmet", "chestplate", "leggings", "boots", "pickaxe", "shovel", "axe", "sword", "hoe", "brush", "fishing_rod",
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "pickaxe", "shovel", "axe", "sword", "hoe", "brush", "fishing_rod",
                 "bow", "shears", "flint_and_steel", "carrot_on_a_stick", "warped_fungus_on_a_stick", "shield", "elytra", "trident",
                 "turtle_shell", "crossbow"
             ],
@@ -265,14 +264,14 @@ var data = {
             levelMax: "1",
             weight: "4",
             incompatible: [],
-            items: ["helmet", "chestplate", "leggings", "boots", "elytra", "pumpkin", "helmet", "turtle_shell"],
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "elytra", "pumpkin", "helmet", "turtle_shell"],
             stylized: "Curse of Binding"
         },
         vanishing_curse: {
             levelMax: "1",
             weight: "4",
             incompatible: [],
-            items: ["helmet", "chestplate", "leggings", "boots", "pickaxe", "shovel", "axe", "sword", "hoe", "brush", "fishing_rod",
+            items: ["book", "helmet", "chestplate", "leggings", "boots", "pickaxe", "shovel", "axe", "sword", "hoe", "brush", "fishing_rod",
                 "bow", "shears", "flint_and_steel", "carrot_on_a_stick", "warped_fungus_on_a_stick", "shield", "elytra", "pumpkin",
                 "helmet", "trident", "turtle_shell", "crossbow"
             ],

--- a/index.html
+++ b/index.html
@@ -47,9 +47,15 @@
                 <div id="enchants" style="display: none">
                     <table></table>
 
-                    <div id="overrides" style="display: none">
-                        <p>
-                        </p>
+                    <div id="overrides" style="">
+                        <div>
+                            <input type="checkbox" id="allow_incompatible" onchange="allowIncompatibleChanged()">
+                            <label for="allow_incompatible">Allow incompatible enchantments</label>
+                        </div>
+                        <div>
+                            <input type="checkbox" id="allow_many" onchange="allowManyChanged()">
+                            <label for="allow_incompatible">Allow more than 12 enchantments</label>
+                        </div>
                     </div>
                     <p>
                         <button id="calculate">Calculate &raquo;</button>

--- a/work.js
+++ b/work.js
@@ -127,38 +127,38 @@ function isPositiveInt(obj) {
     return is_int && is_positive;
 }
 
+function hashFromItem(item_obj) {
+    const enchantments_obj = item_obj.enchantments_obj;
+    const enchantment_objs = enchantments_obj.enchantment_objs;
+
+    enchantment_objs_length = enchantment_objs.length;
+    var enchantment_ids = new Array(enchantment_objs_length);
+    var enchantment_levels = new Array(enchantment_objs_length);
+    enchantment_objs.forEach((enchantment_obj, enchantment_index) => {
+        enchantment_ids[enchantment_index] = enchantment_obj.id;
+        enchantment_levels[enchantment_index] = enchantment_obj.level;
+    });
+
+    const sorted_ids = enchantment_ids.sort();
+    var sorted_levels = new Array(enchantment_objs_length);
+
+    sorted_ids.forEach((id, id_index) => {
+        sorted_levels[id_index] = enchantment_ids[enchantment_ids.indexOf(id)];
+    });
+
+    const item_namespace = item_obj.item_namespace;
+    const prior_work = item_obj.prior_work;
+    const item_hash = [item_namespace, sorted_ids, sorted_levels, prior_work];
+    return item_hash;
+}
+
 function memoizeHashFromArguments(arguments) {
     enchanted_item_objs = arguments[0];
     enchanted_item_hashes = new Array(enchanted_item_objs.length);
 
     enchanted_item_objs.forEach((enchanted_item_obj, enchanted_item_index) => {
-        const enchantments_obj = enchanted_item_obj.enchantments_obj;
-        const enchantment_objs = enchantments_obj.enchantment_objs;
-
-        enchantment_objs_length = enchantment_objs.length;
-        var enchantment_ids = new Array(enchantment_objs_length);
-        var enchantment_levels = new Array(enchantment_objs_length);
-        enchantment_objs.forEach((enchantment_obj, enchantment_index) => {
-            enchantment_ids[enchantment_index] = enchantment_obj.id;
-            enchantment_levels[enchantment_index] = enchantment_obj.level;
-        });
-
-        const sorted_ids = enchantment_ids.sort();
-        var sorted_levels = new Array(enchantment_objs_length);
-
-        sorted_ids.forEach((id, id_index) => {
-            sorted_levels[id_index] = enchantment_ids[enchantment_ids.indexOf(id)];
-        });
-
-        enchanted_item_hashes[enchanted_item_index] = [
-            enchanted_item_obj.item_namespace,
-            sorted_ids,
-            sorted_levels,
-            enchanted_item_obj.prior_work,
-            enchantments_obj.levels,
-            enchantments_obj.merge_levels,
-            enchanted_item_obj.cumulative_levels
-        ];
+        const item_hash = hashFromItem(enchanted_item_obj);
+        enchanted_item_hashes[enchanted_item_index] = item_hash;
     });
 
     return enchanted_item_hashes;

--- a/work.js
+++ b/work.js
@@ -175,7 +175,7 @@ const memoizeCheapest = func => {
     };
 };
 
-function cheapestLevels(item_obj1, item_obj2) {
+function compareCheapest(item_obj1, item_obj2) {
     var work2item = {};
 
     let prior_work1;
@@ -203,7 +203,15 @@ function cheapestLevels(item_obj1, item_obj2) {
     if (prior_work1 === prior_work2) {
         const cumulative_levels1 = item_obj1.cumulative_levels,
             cumulative_levels2 = item_obj2.cumulative_levels;
-        if (cumulative_levels1 < cumulative_levels2) {
+        if (cumulative_levels1 === cumulative_levels2) {
+            const cumulative_minimum_xp1 = item_obj1.cumulative_minimum_xp,
+                cumulative_minimum_xp2 = item_obj2.cumulative_minimum_xp;
+            if (cumulative_minimum_xp1 <= cumulative_minimum_xp2) {
+                work2item[prior_work1] = item_obj1;
+            } else {
+                work2item[prior_work2] = item_obj2;
+            }
+        } else if (cumulative_levels1 < cumulative_levels2) {
             work2item[prior_work1] = item_obj1;
         } else {
             work2item[prior_work2] = item_obj2;
@@ -214,13 +222,6 @@ function cheapestLevels(item_obj1, item_obj2) {
     }
 
     return work2item;
-}
-
-function compareCheapest(item_obj1, item_obj2, cheap_definition = 0) {
-    switch (cheap_definition) {
-        case 0:
-            return cheapestLevels(item_obj1, item_obj2);
-    }
 }
 
 function cheapestItemFromDictionaryByPriorWork(work2item) {

--- a/work.js
+++ b/work.js
@@ -287,6 +287,23 @@ function cheapestItemFromItems2(left_item_obj, right_item_obj) {
     return cheapest_item_obj;
 }
 
+function removeExpensiveCandidatesFromDictionary(work2item) {
+    var cheapest_work2item = {};
+    var cheapest_levels;
+
+    for (let prior_work in work2item) {
+        const item_obj = work2item[prior_work];
+        const cumulative_levels = item_obj.cumulative_levels;
+
+        if (!(cumulative_levels >= cheapest_levels)) {
+            cheapest_work2item[prior_work] = item_obj;
+            cheapest_levels = cumulative_levels;
+        }
+    }
+
+    return cheapest_work2item;
+}
+
 function cheapestItemsFromDictionaries2(left_work2item, right_work2item) {
     var cheapest_work2item = {};
     var cheapest_prior_works = [];
@@ -326,6 +343,7 @@ function cheapestItemsFromDictionaries2(left_work2item, right_work2item) {
         }
     }
 
+    cheapest_work2item = removeExpensiveCandidatesFromDictionary(cheapest_work2item);
     return cheapest_work2item;
 }
 


### PR DESCRIPTION
First two commits: Some moderate speed improvements (~25% for God boots with both curses).

Third commit: The final output instructions are a bit different. It finds the lowest cost by levels or prior work (as before), but they now try to minimize XP cost afterward. It does find a lower XP cost (checked with God boots that have all 7 enchantments), but I'm not 100% sure (at least not yet!) that it's finding the minimum-possible XP cost, as there could be some weird edge cases that I'm missing.

Last commit: Add ability to enchant book without tool, which I think addresses issue #16. 12 books takes about 1min, so more than this is not recommended. By default, there is now a maximum selection limit (12 at the moment), where the user will be alerted, but there is an override to allow more than 12. This limit is adjustable.