### PR TITLE
Arbitrary Definition of Cheapness

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,11 @@
     <head>
         <title>Minecraft Enchantment Ordering Tool</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <script src="https://code.jquery.com/jquery-3.6.0.slim.min.js" integrity="sha256-u7e5khyithlIdTpu22PHhENmPcRdFiHRjhAuHcs05RI=" crossorigin="anonymous"></script>
+        <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+        <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
         <script src="data.js?8"></script>
         <script src="script.js?8"></script>
+        <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
         <link rel="stylesheet" type="text/css" href="style.css?2">
     </head>
     <body>
@@ -70,16 +72,14 @@
 
             <div id="right">
 
-                <p id="mode_selection">
-                    Optimize for:
-                    <label>
-                        <input type="radio" name="cheapness-mode" checked="checked" value="levels">
-                        Least XP/Levels
-                    </label>
-                    <label>
-                        <input type="radio" name="cheapness-mode" value="prior_work">
-                        Least Prior Work Penalty
-                    </label>
+                <p id="mode-selection-container">
+                    <span id="mode-selection-header">Optimize Priority:</span>
+                    <ul id="mode-selection">
+                        <li class="ui-state-default mode-choice" name="cumulative-levels">Total Levels</li>
+                        <li class="ui-state-default mode-choice" name="prior-work">Prior Work</li>
+                        <li class="ui-state-default mode-choice" name="minimum-xp">Minimum XP</li>
+                        <li class="ui-state-default mode-choice" name="max-step">Max Levels Per Step</li>
+                    </ul>
                 </p>
 
                 <div id="progress" style="display: none">

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <title>Minecraft Enchantment Ordering Tool</title>
@@ -47,7 +48,7 @@
                 <div id="enchants" style="display: none">
                     <table></table>
 
-                    <div id="overrides" style="">
+                    <div id="overrides" style="display: none">
                         <div>
                             <label>
                                 <input type="checkbox" id="allow_incompatible" onchange="allowIncompatibleChanged()">

--- a/style.css
+++ b/style.css
@@ -65,6 +65,21 @@ body {
     background-color: #cfc;
 }
 
+#mode-selection {
+    list-style-type: none;
+}
+
+#mode-selection-header {
+    text-align: left;
+}
+
+.mode-choice {
+    display: block;
+    float: left;
+    margin: 0px;
+    padding: 6px;
+}
+
 #calculate {
     padding: 8px;
     font-size: 120%;
@@ -196,7 +211,8 @@ body.dark-mode {
     color: #ffffff;
 }
 
-body.dark-mode h1, body.dark-mode h2 {
+body.dark-mode h1,
+body.dark-mode h2 {
     color: #ffffff;
 }
 
@@ -220,17 +236,17 @@ body.dark-mode .footer {
 
 body.dark-mode #enchants tr.group1 td {
     color: #333;
-    background-color: #CCC;
+    background-color: #ccc;
 }
 
 body.dark-mode #enchants tr.group2 td {
     color: #333;
-    background-color: #BBB;
+    background-color: #bbb;
 }
 
 body.dark-mode #enchants button.on {
     color: #f8f8f8;
-    background-color: #0E754D;
+    background-color: #0e754d;
 }
 
 body.dark-mode #progress {

--- a/work.js
+++ b/work.js
@@ -49,6 +49,8 @@ onmessage = function(event) {
 };
 
 function process(item_namespace, enchantment_foundation, cheapness_definition_raw) {
+    clearMemoizeCache();
+
     const prior_work_index = cheapness_definition_raw.indexOf(-1);
     const prior_work_is_priority = prior_work_index === 0;
 
@@ -172,9 +174,14 @@ function memoizeHashFromArguments(arguments) {
     return enchanted_item_hashes;
 }
 
+function clearMemoizeCache() {
+    cheapestItemsFromList.clearCache();
+}
+
 const memoizeCheapest = func => {
     var results = {};
-    return (...arguments) => {
+
+    const memory = function(...arguments) {
         const memoize_hash = memoizeHashFromArguments(arguments);
         let result = results[memoize_hash];
         if (!result) {
@@ -183,6 +190,11 @@ const memoizeCheapest = func => {
         }
         return result;
     };
+
+    memory.clearCache = function() {
+        results = {};
+    };
+    return memory;
 };
 
 function cheaperItemByLevelPerStep(item_obj1, item_obj2) {


### PR DESCRIPTION
The user can now choose an arbitrary definition of cheapness from 1) least total levels, 2) least prior work, 3) least minimum XP, and 4) least maximum level at any given step. The styling needs some work (I'm a newbie with CSS styling, but am starting to learn!), but it is functional, can be tested on God boots (10 enchantments). The leftmost item has highest priority, then the second one has next priority and so on... so the lower priority choices can break ties. This priority ranking does come at the cost of resetting the memoize cache between calculations, but this should be a problem, because they seem to still be pretty fast,

If there are more possible definitions of cheapness, please let me know! I will try add all that we come up with. The current definitions are very neat to mess around with and see slight changes in the optimal instructions.