### PR TITLE
Fixed experienceFromLevel calculation if level <= 16

### DIFF
--- a/work.js
+++ b/work.js
@@ -542,7 +542,7 @@ function experienceFromLevel(level) {
     if (level == 0) {
         return 0;
     } else if (level <= 16) {
-        return level * level + 7;
+        return level * level + 6 * level
     } else if (level <= 31) {
         return 2.5 * level * level - 40.5 * level + 360;
     } else {


### PR DESCRIPTION
The wrong formula is currently being used to calculate experience from levels.

![image](https://github.com/iamcal/enchant-order/assets/158224886/64983500-f63e-496f-b2e5-4954e504f52b)


Source:https://minecraft.wiki/w/Experience